### PR TITLE
Custom logger Support

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -33,6 +33,11 @@ var throwError = function(msg) {
   throw new Error('CDN: ' + msg);
 };
 
+// Default Log Handler
+var logger = function(msg) {
+  console.log(msg);
+};
+
 // `escape` function from Lo-Dash v0.2.2 <http://lodash.com>
 // and Copyright 2012 John-David Dalton <http://allyoucanleet.com/>
 // MIT licensed <http://lodash.com/license>
@@ -159,7 +164,7 @@ var compile = function(fileName, assets, S3, options, method, type, timestamp) {
             if (response.statusCode !== 200)
               throwError('unsuccessful upload of script "' + fileName + '" to S3');
             else
-              console.log('successfully uploaded script "' + fileName + '" to S3');
+              logger('successfully uploaded script "' + fileName + '" to S3');
           });
         });
         break;
@@ -172,7 +177,7 @@ var compile = function(fileName, assets, S3, options, method, type, timestamp) {
             if (response.statusCode !== 200)
               throwError('unsuccessful upload of stylesheet "' + fileName + '" to S3');
             else
-              console.log('successfully uploaded stylesheet "' + fileName + '" to S3');
+              logger('successfully uploaded stylesheet "' + fileName + '" to S3');
           });
         });
         break;
@@ -180,13 +185,13 @@ var compile = function(fileName, assets, S3, options, method, type, timestamp) {
         var img = path.join(options.publicDir, assets);
         var optipng = spawn('optipng', [img]);
         optipng.stdout.on('data', function(data) {
-          console.log('optipng: ' + data);
+          logger('optipng: ' + data);
         });
         optipng.stderr.on('data', function(data) {
           throwError(data);
         });
         optipng.on('exit', function(code) {
-          console.log('optipng exited with code ' + code);
+          logger('optipng exited with code ' + code);
           fs.readFile(img, function(err, data) {
             zlib.gzip(data, function(err, buffer) {
               S3.putGzipBuffer(buffer, encodeURIComponent(fileName), headers, function(err, response) {
@@ -194,7 +199,7 @@ var compile = function(fileName, assets, S3, options, method, type, timestamp) {
                 if (response.statusCode !== 200)
                   throwError('unsuccessful upload of image "' + fileName + '" to S3');
                 else
-                  console.log('successfully uploaded image "' + fileName + '" to S3');
+                  logger('successfully uploaded image "' + fileName + '" to S3');
                   // Hack to preserve original timestamp for view helper
                   fs.utimesSync(img, new Date(timestamp), new Date(timestamp));
               });
@@ -206,13 +211,13 @@ var compile = function(fileName, assets, S3, options, method, type, timestamp) {
         var jpg = path.join(options.publicDir, assets);
         var jpegtran = spawn('jpegtran', [ '-copy', 'none', '-optimize', '-outfile', jpg, jpg ]);
         jpegtran.stdout.on('data', function(data) {
-          console.log('jpegtran: ' + data);
+          logger('jpegtran: ' + data);
         });
         jpegtran.stderr.on('data', function(data) {
           throwError(data);
         });
         jpegtran.on('exit', function(code) {
-          console.log('jpegtran exited with code ' + code);
+          logger('jpegtran exited with code ' + code);
           fs.readFile(jpg, function(err, data) {
             zlib.gzip(data, function(err, buffer) {
               S3.putGzipBuffer(buffer, encodeURIComponent(fileName), headers, function(err, response) {
@@ -220,7 +225,7 @@ var compile = function(fileName, assets, S3, options, method, type, timestamp) {
                 if (response.statusCode !== 200)
                   throwError('unsuccessful upload of image "' + fileName + '" to S3');
                 else
-                  console.log('successfully uploaded image "' + fileName + '" to S3');
+                  logger('successfully uploaded image "' + fileName + '" to S3');
                   // Hack to preserve original timestamp for view helper
                   fs.utimesSync(jpg, new Date(timestamp), new Date(timestamp));
               });
@@ -249,9 +254,9 @@ var checkArrayIfModified = function(assets, fileName, S3, options, type) {
   return function(err, response) {
     if (err) throwError(err);
     if (response.statusCode === 200) {
-      console.log('"' + fileName + '" not modified and is already stored on S3');
+      logger('"' + fileName + '" not modified and is already stored on S3');
     } else {
-      console.log('"' + fileName + '" was not found on S3 or was modified recently');
+      logger('"' + fileName + '" was not found on S3 or was modified recently');
       // Check file type
       switch(type) {
         case 'application/javascript':
@@ -272,9 +277,9 @@ var checkStringIfModified = function(assets, fileName, S3, options, timestamp) {
   return function(err, response) {
     if (err) throwError(err);
     if (response.statusCode === 200) {
-      console.log('"' + fileName + '" not modified and is already stored on S3');
+      logger('"' + fileName + '" not modified and is already stored on S3');
     } else {
-      console.log('"' + fileName + '" was not found on S3 or was modified recently');
+      logger('"' + fileName + '" was not found on S3 or was modified recently');
       // Check file type
       var type = mime.lookup(assets);
       switch(type) {
@@ -376,6 +381,9 @@ var CDN = function(app, options) {
       throwError('missing option "' + options[index] + '"');
   });
 
+  if(options.logger) {
+    logger = options.logger;
+  }
   if (options.production) {
 
     var walker   = walk.walk(options.viewsDir)


### PR DESCRIPTION
This adds the ability to pass an optional logger function as an option.
The default is to output to console.log()

I use the excellent [Winston](https://github.com/flatiron/winston/) library to manage my logs, so in this case I would pass in my logging function like so:

``` javascript
var options = {
  // Other options
  logger: winston.info
}
var CDN = require('express-cdn')(express, options);
express.dynamicHelpers({ CDN: CDN });
```
