### PR TITLE
Fix file walker

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -390,9 +390,9 @@ var CDN = function(app, options) {
           while( (match = regexCDN.exec(data)) ) {
             results.push(match[1]);
           }
-          next();
         });
       }
+      next();
     });
     walker.on('end', function() {
       // Clean the array


### PR DESCRIPTION
The file walker stops on unrecognised files (such as .DS_STORE)

Moved the next(); call to outside of the if block.
