### PR TITLE
Added support for custom logger functions

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -380,7 +380,7 @@ var CDN = function(app, options) {
       throwError('missing option "' + options[index] + '"');
   });
 
-  if(options.logger) {
+  if (options.logger) {
     if(typeof options.logger === 'function')
       logger = options.logger;
   }


### PR DESCRIPTION
Adds the ability to pass a custom logging function as an option.
The default is still console.log()

I use the excellent [winston](https://github.com/flatiron/winston/) library to manage logs, so in this case I would pass my winston log function to express-cdn:

``` javascript
var options = {
  // other options
  logger: winston.info
}

var CDN = require('express-cdn')(express, options);
express.dynamicHelpers({ CDN: CDN });
```
