### PR TITLE
Added compatibility with express 3.x.x

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -151,7 +151,8 @@ npm install express-cdn
 
 var express = require('express')
   , path    = require('path')
-  , app     = express.createServer();
+  , app     = express.createServer()
+  , semver  = require('semver');
 
 // Set the CDN options
 var options = {
@@ -178,8 +179,12 @@ app.configure(function() {
   app.use(express.static(path.join(__dirname, 'public')));
 });
 
-// Add the dynamic view helper
-app.dynamicHelpers({ CDN: CDN });
+// Add the view helper
+if (semver.lt(express.version, '3.0.0')) {
+  app.locals({ CDN: CDN() });
+} else {
+  app.dynamicHelpers({ CDN: CDN });
+}
 
 app.get('/', function(req, res, next) {
   res.render('basic');

--- a/lib/main.js
+++ b/lib/main.js
@@ -359,8 +359,8 @@ var processAssets = function(options, results) {
 
 var CDN = function(app, options) {
 
-  // Validate express
-  if (typeof app !== 'object') throwError('requires express');
+  // Validate express - Express app instance is an object in v2.x.x and function in 3.x.x
+  if (!(typeof app === 'object' || typeof app === 'function')) throwError('requires express');
 
   // Validate options
   var required = [


### PR DESCRIPTION
I added compatibility with Express 3.x.x by checking if app was typeof function or object. I added a comment just so we know why that line is the way it is. I tried to check if there was an attribute on the app object or its prototype to see that it is an express object, but I didn't find one. Ideally TJ Holowaychuk could add an attribute on the app instance to identity itself as Express and the version number.

I also added a few lines to the usage example. To show people how to use it with both Express 2.x and 3.x, I had to add a dependency on Isaacs' semver lib.

Same as this, but I couldn't figure out how to attach my pull request to this issue:
https://github.com/niftylettuce/express-cdn/issues/14
