### PR TITLE
Enable string-only output

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -60,6 +60,10 @@ var renderAttributes = function(attributes) {
 var createTag = function(src, asset, attributes, version) {
   // Cachebusting
   version = version || '';
+  // Enable "raw" output
+  if ('raw' in attributes && attributes.raw === true) {
+    return src + asset + version;
+  }
   // Check mime type
   switch(mime.lookup(asset)) {
     case 'application/javascript':


### PR DESCRIPTION
I needed a way to just grab the url / path the helper generates. Just add `raw : true`as an attribute and you'll just get the url / path back.

**Example:**

```
- var href = CDN('/img/full/foo.jpg', { raw : true });
a(class="fancybox", href="#{href}")
  != CDN('/img/small/foo.jpg', { alt : 'Foo', width : 800, height : 600 })
```
