### PR TITLE
Allow using non US Standard S3 regions

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -117,7 +117,8 @@ Assets are optimized, minified, mangled, gzipped, delivered by Amazon CloudFront
 
 1. Visit <https://console.aws.amazon.com/s3/home> and click **Create Bucket**.
   * Bucket Name: `bucket-name`
-  * Region: `US Standard`
+  * Region: `US Standard` (use `options.endpoint`
+    with `'bucket.s3-xxx.amazonaws.com'` for non `US Standard` regions)
 2. Upload <a href="https://raw.github.com/niftylettuce/express-cdn/master/index.html">index.html</a> to your new bucket (this will serve as a placeholder in case someone accesses <http://cdn.your-site.com/>).
 3. Select `index.html` in the Objects and Folders view from your S3 console and click **Actions &rarr; Make Public**.
 4. Visit <https://console.aws.amazon.com/cloudfront/home> and click **Create Distribution**.
@@ -180,6 +181,7 @@ var options = {
   , viewsDir   : path.join(__dirname, 'views')
   , domain     : 'cdn.your-domain.com'
   , bucket     : 'bucket-name'
+  , endpoint   : 'bucket-name.s3-eu-west-1.amazonaws.com' // optional
   , key        : 'amazon-s3-key'
   , secret     : 'amazon-s3-secret'
   , hostname   : 'localhost'

--- a/examples/basic.js
+++ b/examples/basic.js
@@ -11,6 +11,7 @@ var options = {
   , viewsDir   : path.join(__dirname, 'views')
   , domain     : 'cdn.your-domain.com'
   , bucket     : 'bucket-name'
+  , endpoint   : 'bucket-name.s3-eu-west-1.amazonaws.com' // optional
   , key        : 'amazon-s3-key'
   , secret     : 'amazon-s3-secret'
   , hostname   : 'localhost'

--- a/lib/main.js
+++ b/lib/main.js
@@ -351,6 +351,7 @@ var processAssets = function(options, results) {
       key: options.key
     , secret: options.secret
     , bucket: options.bucket
+    , endpoint: options.endpoint
   });
   // Go through each result and process it
   for(var i=0; i<results.length; i+=1) {


### PR DESCRIPTION
When hosting data on non US Standard regions, S3 sometimes redirects requests (see
[this](https://forums.aws.amazon.com/message.jspa?messageID=196878) for more details). 

This change propagates the `endpoint` option to `knox`, which allows explicitly specifying the S3 endpoint.

Updated readme and sample.
