### PR TITLE
PNG optimizations fail with OptiPNG v0.7 or higher

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -205,6 +205,9 @@ var compile = function(fileName, assets, S3, options, method, type, timestamp) {
         optipng.stdout.on('data', function(data) {
           logger({ task: 'express-cdn', message: 'optipng: ' + data });
         });
+        optipng.stderr.on('data', function(data) {
+          logger({ task: 'express-cdn', message: 'optipng: ' + data });
+        });
         optipng.on('exit', function(code) {
           // OptiPNG returns 1 if an error occurs
           if (code != 0) 


### PR DESCRIPTION
OptiPNG outputs its activity log to STDERR since [v0.7](http://optipng.sourceforge.net/history.txt).

So with the latest OptiPNG, all png optimizations fail because express-cdn throws an error if something is written to STDERR from an OptiPNG process.
