### PR TITLE
Fix newline when requesting raw string

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -325,12 +325,7 @@ var checkStringIfModified = function(assets, fileName, S3, options, timestamp) {
           readUtf8(path.join(options.publicDir, assets), compile(fileName, assets, S3, options, 'uglify', type));
           return;
         case 'text/css':
-          readCSS(url.format({
-            protocol: (options.ssl) ? 'https' : 'http',
-            hostname: options.hostname,
-            port: options.port,
-            pathname: assets
-          }), compile(fileName, assets, S3, options, 'minify', type));
+          readUtf8(path.join(options.publicDir, assets), compile(fileName, assets, S3, options, 'minify', type));
           return;
         case 'image/png':
         case 'image/gif':


### PR DESCRIPTION
Hackish workaround for getting rid of the newline character when raw attribute is set.
