### PR TITLE
More robust asset parsing in production mode

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -465,9 +465,12 @@ var CDN = function(app, options, callback) {
 
   if (options.production) {
     var walker = function () {
+
       var walker   = walk.walk(options.viewsDir)
         , results  = []
-        , regexCDN = /CDN\(([^)]+)\)/g;
+        , regexCDN = /CDN\(([^)]+)\)/g
+        , regexArray = /\[([^)]+)\]/g;
+
       walker.on('file', function(root, stat, next) {
         var validExts = options.extensions || ['.jade', '.ejs'];
         var ext = path.extname(stat.name), text;
@@ -484,30 +487,26 @@ var CDN = function(app, options, callback) {
           next();
         }
       });
+
       walker.on('end', function() {
-        // Clean the array
-        for (var i=0; i<results.length; i+=1) {
+
+        // Clean results -> get assets
+        var clean = results.map(function(item) {
           // Convert all apostrophes
-          results[i] = results[i].replace(/\'/g, '"');
-          // Insert assets property name
-          results[i] = _(results[i]).splice(0, 0, '"assets": ');
-          // Check for attributes
-          var attributeIndex = results[i].indexOf('{');
-          if (attributeIndex !== -1)
-            results[i] = _(results[i]).splice(attributeIndex,0,'"attributes": ');
-          // Convert to an object
-          results[i] = '{ ' + results[i] + ' }';
-          results[i] = JSON.parse(results[i]);
-        }
-        // Convert to an array of only assets
-        var out = [];
-        for (var k=0; k<results.length; k+=1) {
-          out[results[k].assets] = results[k].assets;
-        }
-        var clean = [];
-        for (var c in out) {
-          clean.push(out[c]);
-        }
+          item = item.replace(/\'/g, '"');
+          // Kill whitespace
+          item = item.replace(/\s/g, '');
+          // Split asset string / attribute string and grab asset string
+          item = item.split(',{')[0];
+          // Check if asset string is an array
+          var matchAssetArray = regexArray.exec( item );
+          if ( matchAssetArray ) {
+            item = matchAssetArray[1].split(',');
+          }
+          // return asset(s)
+          return item;
+        });
+
         // Process the results
         if (clean.length > 0) {
           processAssets(options, clean, function (err, results) {
@@ -520,6 +519,7 @@ var CDN = function(app, options, callback) {
         } else {
           throwError('empty results');
         }
+
       });
     };
 


### PR DESCRIPTION
This fixes an error, which appears when you forgot to put attributes into qoutes and try to run your application in production mode.

Look at this thread for more information: https://github.com/niftylettuce/express-cdn/pull/19#issuecomment-11074475
