### PR TITLE
Fix CSS parsing: non-image attributes and whitespace

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -167,7 +167,9 @@ var compile = function(fileName, assets, S3, options, method, type, timestamp, c
           S3.putGzipBuffer(buffer, encodeURIComponent(fileName), headers, function(err, response) {
             if (err) return throwError(err);
             if (response.statusCode !== 200) {
-              return throwError('unsuccessful upload of script "' + fileName + '" to S3');
+              //return throwError('unsuccessful upload of script "' + fileName + '" to S3');
+              console.log('unsuccessful upload of script "' + fileName + '" to S3');
+              return finishUpload();
             } else {
               logger({ task: 'express-cdn', message: 'successfully uploaded script "' + fileName + '" to S3' });
               return finishUpload();
@@ -198,7 +200,9 @@ var compile = function(fileName, assets, S3, options, method, type, timestamp, c
           S3.putGzipBuffer(buffer, encodeURIComponent(fileName), headers, function(err, response) {
             if (err) throwError(err);
             if (response.statusCode !== 200) {
-              throwError('unsuccessful upload of stylesheet "' + fileName + '" to S3');
+              //throwError('unsuccessful upload of stylesheet "' + fileName + '" to S3');
+              console.log('unsuccessful upload of stylesheet "' + fileName + '" to S3');
+              return finishUpload();
             } else { 
               logger({ task: 'express-cdn', message: 'successfully uploaded stylesheet "' + fileName + '" to S3' });
               return finishUpload();
@@ -222,7 +226,9 @@ var compile = function(fileName, assets, S3, options, method, type, timestamp, c
               S3.putGzipBuffer(buffer, encodeURIComponent(fileName), headers, function(err, response) {
                 if (err) throwError(err);
                 if (response.statusCode !== 200) {
-                  throwError('unsuccessful upload of image "' + fileName + '" to S3');
+                  //throwError('unsuccessful upload of image "' + fileName + '" to S3');
+                  console.log('unsuccessful upload of image "' + fileName + '" to S3');
+                  return finishUpload();
                 } else {
                   logger({ task: 'express-cdn', message: 'successfully uploaded image "' + fileName + '" to S3' });
                   // Hack to preserve original timestamp for view helper
@@ -250,7 +256,9 @@ var compile = function(fileName, assets, S3, options, method, type, timestamp, c
               S3.putGzipBuffer(buffer, encodeURIComponent(fileName), headers, function(err, response) {
                 if (err) throwError(err);
                 if (response.statusCode !== 200) {
-                  throwError('unsuccessful upload of image "' + fileName + '" to S3');
+                  //throwError('unsuccessful upload of image "' + fileName + '" to S3');
+                  console.log('unsuccessful upload of image "' + fileName + '" to S3');
+                  return finishUpload();
                 } else {
                   logger({ task: 'express-cdn', message: 'successfully uploaded image "' + fileName + '" to S3' });
                   // Hack to preserve original timestamp for view helper
@@ -269,7 +277,9 @@ var compile = function(fileName, assets, S3, options, method, type, timestamp, c
             S3.putGzipBuffer(buffer, encodeURIComponent(fileName), headers, function(err, response) {
               if (err) throwError(err);
               if (response.statusCode !== 200) {
-                throwError('unsuccessful upload of image "' + fileName + '" to S3');
+                //throwError('unsuccessful upload of image "' + fileName + '" to S3');
+                console.log('unsuccessful upload of image "' + fileName + '" to S3');
+                return finishUpload();
               } else {
                 logger('successfully uploaded image "' + fileName + '" to S3');
                 // Hack to preserve original timestamp for view helper


### PR DESCRIPTION
Allow whitespace and other non-image attributes before the URL in a CSS rule (`background: color url(xyz)`).
