### PR TITLE
Add ability to specify template extension

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -203,7 +203,7 @@ var compile = function(fileName, assets, S3, options, method, type, timestamp, c
               //throwError('unsuccessful upload of stylesheet "' + fileName + '" to S3');
               console.log('unsuccessful upload of stylesheet "' + fileName + '" to S3');
               return finishUpload();
-            } else { 
+            } else {
               logger({ task: 'express-cdn', message: 'successfully uploaded stylesheet "' + fileName + '" to S3' });
               return finishUpload();
             }
@@ -221,7 +221,7 @@ var compile = function(fileName, assets, S3, options, method, type, timestamp, c
         });
         optipng.on('exit', function(code) {
           // OptiPNG returns 1 if an error occurs
-          if (code != 0) 
+          if (code != 0)
             throwError('optipng returned an error during processing \'' + img + '\': ' + code);
 
           logger({ task: 'express-cdn', message: 'optipng exited with code ' + code });
@@ -287,7 +287,7 @@ var compile = function(fileName, assets, S3, options, method, type, timestamp, c
               } else {
                 logger('successfully uploaded image "' + fileName + '" to S3');
                 // Hack to preserve original timestamp for view helper
-                try { 
+                try {
                   fs.utimesSync(image, new Date(timestamp), new Date(timestamp));
                   return finishUpload();
                 } catch (e) {
@@ -469,8 +469,9 @@ var CDN = function(app, options, callback) {
         , results  = []
         , regexCDN = /CDN\(([^)]+)\)/g;
       walker.on('file', function(root, stat, next) {
+        var validExts = options.extensions || ['.jade', '.ejs'];
         var ext = path.extname(stat.name), text;
-        if (ext === '.jade' || ext === '.ejs') {
+        if (_.indexOf(validExts, ext) !== -1) {
           fs.readFile(path.join(root, stat.name), 'utf8', function(err, data) {
             if (err) throwError(err);
             var match;


### PR DESCRIPTION
Currently when in production mode, only .ejs and .jade templates are scanned for CDN() usage.  I'm using [swig templates](http://paularmstrong.github.com/swig/).  These files have a '.html' extension.  

This pull requests adds the ability to specify 'extensions' via the options when different than the default.

```
{
  // ...
  extensions : ['.html']
}
```
