### PR TITLE
Fixes #32

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -502,7 +502,7 @@ var CDN = function(app, options, callback) {
     var walker = function () {
       var walker   = walk.walk(options.viewsDir)
         , results  = []
-        , regexCDN = /CDN\(([^)]+)\)/g;
+        , regexCDN = /CDN\(([^)]+)\)/ig;
       walker.on('file', function(root, stat, next) {
         var validExts = options.extensions || ['.jade', '.ejs'];
         var ext = path.extname(stat.name), text;


### PR DESCRIPTION
Use a case-insensitive regexp to catch both `CDN` and `cdn`.
