### PR TITLE
Keep license comments. UglifyJS 2 upgrade.

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -20,8 +20,7 @@ var fs       = require('fs')
   , async    = require('async')
   , request  = require('request')
   , _        = require('underscore')
-  , jsp      = require('uglify-js').parser
-  , pro      = require('uglify-js').uglify
+  , uglify   = require('uglify-js')
   , spawn    = require('child_process').spawn
   , optipngPath = require('optipng-bin').path
   , jpegtranPath = require('jpegtran-bin').path
@@ -163,10 +162,10 @@ var compile = function(fileName, assets, S3, options, method, type, timestamp, c
     switch(method) {
       case 'uglify':
         if (results instanceof Array) results = results.join("\n");
-        var ast = jsp.parse(results);
-        ast = pro.ast_mangle(ast);
-        ast = pro.ast_squeeze(ast);
-        var final_code = pro.gen_code(ast);
+        var final_code = uglify.minify(results,{
+            fromString: true
+          , output : { comments : '/license/' } 
+        }).code;
         zlib.gzip(final_code, function(err, buffer) {
           if (err) throwError(err);
           S3.putBuffer(buffer, encodeURIComponent(fileName), headers, function(err, response) {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,10 @@
     {
       "name": "Elad Ben-Israel",
       "email": "elad.benisrael@gmail.com"
+    },
+    {
+      "name": "Mateusz Wielgos",
+      "email": "wielgosm@gmail.com"
     }
   ],
   "keywords": [
@@ -76,7 +80,7 @@
     "walk": "~2.2.1",
     "async": "~0.2.9",
     "request": "~2.16.6",
-    "uglify-js": "~1.3.5",
+    "uglify-js": "~2.4.3",
     "underscore.string": "~2.3.1"
   },
   "dependencies": {
@@ -84,7 +88,7 @@
     "underscore": "~1.3.3",
     "walk": "~2.2.1",
     "async": "~0.2.9",
-    "uglify-js": "~1.3.5",
+    "uglify-js": "~2.4.3",
     "optipng-bin": "~0.3",
     "jpegtran-bin": "~0.1.4",
     "knox": "~0.8.0",


### PR DESCRIPTION
It would be nice to keep license comments in the combined & minified js files. UglifyJS 1 doesn't have too many options for keeping comments, hence the upgrade is necessary.
