### PR TITLE
Favicon support

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -204,6 +204,9 @@ app.listen(1337);
 
 // #8 - Load and concat two stylesheets
 != CDN([ '/css/style.css', '/css/extra.css' ])
+
+// #9 - Load a favicon
+!= CDN('/img/favicon.ico')
 ```
 
 #### EJS
@@ -232,6 +235,9 @@ app.listen(1337);
 
 <!-- #8 - Load and concat two stylesheets -->
 <%- CDN([ '/css/style.css', '/css/extra.css' ]) %>
+
+<!-- #9 - Load a favicon -->
+<%- CDN('/img/favicon.ico') %>
 ```
 
 ### Automatically Rendered HTML
@@ -265,6 +271,9 @@ app.listen(1337);
 <!-- #8 - Load and concat two stylesheets -->
 <link href="/css/style.css?v=1341214029" rel="stylesheet" type="text/css" />
 <link href="/css/extra.css?v=1341214029" rel="stylesheet" type="text/css" />
+
+<!-- #9 - Load a favicon -->
+<link href="/img/favicon.ico?v=1341214029" rel="shortcut icon" />
 ```
 
 #### Production Mode
@@ -300,6 +309,9 @@ timestamps together and checks if the combined asset timestamp on S3 exists!).
 
 <!-- #8 - Load and concat two stylesheets -->
 <link href="https://cdn.your-site.com/style%2Bextra.1341382571.css" rel="stylesheet" type="text/css" />
+
+<!-- #9 - Load a favicon -->
+<link href="https://cdn.your-site.com/img/favicon.1341382571.ico" rel="shortcut icon" />
 ```
 
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -82,6 +82,11 @@ var createTag = function(src, asset, attributes, version) {
     case 'image/gif':
       attributes.src = src + asset + version;
       return '<img ' + renderAttributes(attributes) + ' />';
+    case 'image/x-icon':
+    case 'image/vnd.microsoft.icon':
+      attributes.rel  = attributes.rel || 'shortcut icon';
+      attributes.href = src + asset + version;
+      return '<link ' + renderAttributes(attributes) + ' />';
     default:
       throwError('unknown asset type');
   }
@@ -418,6 +423,9 @@ var checkStringIfModified = function(assets, fileName, S3, options, timestamp, c
         case 'image/pjpeg':
           compile(fileName, assets, S3, options, 'jpegtran', type, timestamp, finishUpload)(null, null);
           return;
+        case 'image/x-icon':
+        case 'image/vnd.microsoft.icon':
+          compile(fileName, assets, S3, options, 'image', type, timestamp, finishUpload)(null, null);
         default:
           throwError('unsupported mime type "' + type + '"');
       }


### PR DESCRIPTION
Added support for favicons and updated docs accordingly.

There are two acceptable mime types for .ico ( http://en.wikipedia.org/wiki/ICO_(file_format)#MIME_type ):
image/vnd.microsoft.icon - official
image/x-icon

I used the most common way of including a favicon ( http://en.wikipedia.org/wiki/Favicon#How_to_use ):

```
<link href="https://cdn.your-site.com/img/favicon.ico" rel="shortcut icon" />
```

This is obviously a bit hairy as a favicon is an image, so maybe in future revisions there could be some specificity about what should be generated.
