### PR TITLE
Relative http protocol

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -99,8 +99,10 @@ var renderTag = function(options, assets, attributes) {
   // In production mode, check for SSL
   var src = '', position, timestamp = 0;
   if (options.production) {
-    if (options.ssl) {
+    if (options.ssl == 'relative') {
       src = '//' + options.domain; // Allow for http request when ssl is not used
+    } else if (options.ssl) {
+      src = 'https://' + options.domain;
     } else {
       src = 'http://' + options.domain;
     }


### PR DESCRIPTION
Adding 'relative' value to SSL option. There are use case where you need the full 'https' protocol declaration. For example when sending emails, the mail clients don't work with relative protocol declaration (//).