### PR TITLE
fixed wrong mimetypes for minify case in compile method

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -212,7 +212,8 @@ var compile = function(fileName, assets, S3, options, method, type, timestamp, c
                 else {
                   relativePath = path.join(assetBasePath, relativePath);
                 }
-                var imageResource = compile(relativePath.substr(options.publicDir.length + 1), relativePath, S3, options, 'image', 'image/'+path.extname(url).substr(1), Date.now(), null, null)();
+                var mimeType = mime.lookup(relativePath);
+                var imageResource = compile(relativePath.substr(options.publicDir.length + 1), relativePath, S3, options, 'image', mimeType, Date.now(), null, null)();
                 return 'url('+path.relative(fileBasePath, relativePath)+')';
               } else {
                 return 'url('+url+')';
@@ -590,3 +591,4 @@ var CDN = function(app, options, callback) {
 };
 
 module.exports = CDN;
+


### PR DESCRIPTION
When uploading in example svg file, the mime-type is wrong, it is: image/svg, not image/svg+xml and browsers won't render them.

btw: 
Also these files doesn't have cache timestamp when they are requested from server, i dont know if it is on purpose or not.

greets!
