### PR TITLE
Fix uglifyjs license comment regex

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -170,7 +170,7 @@ var compile = function(fileName, assets, S3, options, method, type, timestamp, c
         if (results instanceof Array) results = results.join("\n");
         var final_code = uglify.minify(results,{
             fromString: true
-          , output : { comments : '/license/' } 
+          , output : { comments : /license/ } 
         }).code;
         zlib.gzip(final_code, function(err, buffer) {
           if (err) throwError(err);


### PR DESCRIPTION
Current code is actually a string and not a regex.

This is massive bug (increases my production JS size by a factor of 3), so it'd be great if you could cut a release for it too :)
