### PR TITLE
support svg

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -81,6 +81,7 @@ var createTag = function(src, asset, attributes, version) {
     case 'image/jpeg':
     case 'image/pjpeg':
     case 'image/gif':
+    case 'image/svg+xml':
       attributes.src = src + asset + version;
       return '<img ' + renderAttributes(attributes) + ' />';
     case 'image/x-icon':
@@ -170,7 +171,7 @@ var compile = function(fileName, assets, S3, options, method, type, timestamp, c
         if (results instanceof Array) results = results.join("\n");
         var final_code = uglify.minify(results,{
             fromString: true
-          , output : { comments : /license/ } 
+          , output : { comments : /license/ }
         }).code;
         zlib.gzip(final_code, function(err, buffer) {
           if (err) throwError(err);


### PR DESCRIPTION
Related to https://github.com/niftylettuce/express-cdn/pull/67

When rendering a svg file, the following code will throw Error `CDN: unknown asset type`

```
!= CDN('/img/logo.svg')
```
