### PR TITLE
Better cache timestamp implementation for multiple files

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -115,7 +115,7 @@ var renderTag = function(options, assets, attributes) {
           throwError('mime types in CDN array of assets must all be the same');
         // Push just the file name to the concat array
         concat.push(path.basename(assets[b]));
-        timestamp += fs.statSync(path.join(options.publicDir, assets[b])).mtime.getTime();
+        timestamp = Math.max(timestamp, fs.statSync(path.join(options.publicDir, assets[b])).mtime.getTime());
       }
       var name = concat.join("+");
       position = name.lastIndexOf('.');
@@ -342,9 +342,9 @@ var compile = function(fileName, assets, S3, options, method, type, timestamp, c
                 return finishUpload();
               } else {
                 logger('successfully uploaded image "' + fileName + '" to S3');
-                // Hack to preserve original timestamp for view helper
+                // Hack to preserve original statsync for view helper
                 try {
-                  fs.utimesSync(image, new Date(timestamp), new Date(timestamp));
+                  fs.utimesSync(image, new Date(statsync), new Date(statsync));
                   return finishUpload();
                 } catch (e) {
                   return finishUpload();
@@ -365,7 +365,7 @@ var readUtf8 = function(file, callback) {
 var js = ['application/javascript', 'text/javascript'];
 
 // Check if the file already exists
-var checkArrayIfModified = function(assets, fileName, S3, options, timestamp, type, callback) {
+var checkArrayIfModified = function(assets, fileName, S3, options, statsync, type, callback) {
   var finishUpload = function () {
     return callback && callback(null, assets);
   };


### PR DESCRIPTION
Use the latest file modification date instead of the current method that can be repeated.
