### PR TITLE
Better cache timestamp implementation for multiple files

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -115,7 +115,7 @@ var renderTag = function(options, assets, attributes) {
           throwError('mime types in CDN array of assets must all be the same');
         // Push just the file name to the concat array
         concat.push(path.basename(assets[b]));
-        timestamp += fs.statSync(path.join(options.publicDir, assets[b])).mtime.getTime();
+        timestamp = Math.max(timestamp, fs.statSync(path.join(options.publicDir, assets[b])).mtime.getTime());
       }
       var name = concat.join("+");
       position = name.lastIndexOf('.');


### PR DESCRIPTION
Use the latest file modification date instead of the current method that can be repeated.
