### PR TITLE
Fix get correct timestamp

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -531,9 +531,8 @@ var processAssets = function(options, results, done) {
         if (exists) {
           timestamp = fs.statSync(assets).mtime.getTime();
         }
+        S3.headFile(fileName, checkStringIfModified(assets, fileName, S3, options, timestamp, iter));
       });
-      //fileName = _(fileName).splice(position, 0, '.' + timestamp);
-      S3.headFile(fileName, checkStringIfModified(assets, fileName, S3, options, timestamp, iter));
     }
   }, function(err, results) {
     done(err, results);


### PR DESCRIPTION
This should get the correct timestamp when checking if a file has been changed.
Tested it manual by starting a server with and without a changed asset and checked if the asset actually were uploaded.
Related to #92  