### PR TITLE
encode uri for joined files

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -121,7 +121,7 @@ var renderTag = function(options, assets, attributes) {
         concat.push(path.basename(assets[b]));
         timestamp = Math.max(timestamp, fs.statSync(path.join(options.publicDir, assets[b])).mtime.getTime());
       }
-      var name = concat.join("+");
+      var name = encodeURIComponent(concat.join("+"));
       position = name.lastIndexOf('.');
       //name = _(name).splice(position, 0, '.' + timestamp);
       name = name + '?cache=' + timestamp;


### PR DESCRIPTION
Before:

express-cdn would generate urls with a "+" for joined files. This isn't a valid URI.

Fix: encode the URI so that '+' gets escaped to %2B